### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: clojure
-sudo: required
-lein: lein2
 jdk:
   - oraclejdk8
+  - openjdk11

--- a/project.clj
+++ b/project.clj
@@ -5,11 +5,11 @@
             :url "https://opensource.org/licenses/MIT"
             :year 2016
             :key "mit"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha14" :scope "provided"]
-                 [alumbra/spec "0.1.10" :scope "provided"]
-                 [org.flatland/ordered "1.5.4"]
+  :dependencies [[org.clojure/clojure "1.10.0" :scope "provided"]
+                 [alumbra/spec "0.1.11" :scope "provided"]
+                 [org.flatland/ordered "1.5.7"]
                  [camel-snake-kebab "0.4.0"]
-                 [claro "0.2.18"]]
+                 [claro "0.2.20"]]
   :profiles {:dev {:dependencies [[org.clojure/test.check "0.9.0"]
                                   [alumbra/parser "0.1.7"]
                                   [alumbra/analyzer "0.1.17"]


### PR DESCRIPTION
Makes it possible to run alumbra.claro on Java 11. Older versions of
org.flatland/ordered were not compatible.

See: https://github.com/clj-commons/ordered/pull/37/files